### PR TITLE
Add QR scanner to onboarding, drag & drop file encryption, update outgoing message color

### DIFF
--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -145,11 +145,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
       // send single file — encrypt via Privitty before adding to draft (same as menuAttachment)
       if (sanitized.length == 1) {
         const file = sanitized[0]
-        const enc = await encryptFileForChat(
-          accountId,
-          chat.id,
-          file.pathStr
-        )
+        const enc = await encryptFileForChat(accountId, chat.id, file.pathStr)
         if (!enc) {
           return
         }

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useCallback } from 'react'
-import { join, parse, ParsedPath } from 'path'
+import { basename, join, parse } from 'path'
 import { T } from '@privitty/jsonrpc-client'
 
 import Composer, { useDraft } from '../composer/Composer'
@@ -14,7 +14,8 @@ import ConfirmSendingFiles from '../dialogs/ConfirmSendingFiles'
 import { ReactionsBarProvider } from '../ReactionsBar'
 import useDialog from '../../hooks/dialog/useDialog'
 import useMessage from '../../hooks/chat/useMessage'
-import { Viewtype } from '@privitty/jsonrpc-client/dist/generated/types'
+import { useSharedData } from '../../contexts/FileAttribContext'
+import { encryptFileForChat } from '../../utils/privittyEncryptFile'
 
 const log = getLogger('renderer/MessageListAndComposer')
 
@@ -89,17 +90,13 @@ export function getBackgroundImageStyle(
   return style
 }
 
-function isImage(file: ParsedPath) {
-  const imageExtensions = ['.jpg', '.jpeg', '.png']
-  return imageExtensions.includes(file.ext)
-}
-
 export default function MessageListAndComposer({ accountId, chat }: Props) {
   const conversationRef = useRef<HTMLDivElement>(null)
   const refComposer = useRef(null)
 
   const { openDialog, hasOpenDialogs } = useDialog()
   const { sendMessage } = useMessage()
+  const { setSharedData } = useSharedData()
 
   const regularMessageInputRef = useRef<ComposerMessageInput>(null)
   const editMessageInputRef = useRef<ComposerMessageInput>(null)
@@ -145,15 +142,30 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
         // (unless the file has no extension, then the things are even worse).
         .map(path => ({ parsed: parse(path), pathStr: path }))
 
-      // send single file
+      // send single file — encrypt via Privitty before adding to draft (same as menuAttachment)
       if (sanitized.length == 1) {
         const file = sanitized[0]
-        const msgViewType: Viewtype = isImage(file.parsed) ? 'Image' : 'File'
-        await addFileToDraft(
-          file.pathStr,
-          file.parsed.name + file.parsed.ext,
-          msgViewType
+        const enc = await encryptFileForChat(
+          accountId,
+          chat.id,
+          file.pathStr
         )
+        if (!enc) {
+          return
+        }
+        await addFileToDraft(
+          enc.encryptedPath,
+          basename(enc.encryptedPath),
+          'File'
+        )
+        setSharedData({
+          allowDownload: false,
+          allowForward: false,
+          allowedTime: '',
+          FileDirectory: enc.originalPath,
+          oneTimeKey: enc.oneTimeKey,
+          encryptedFilePath: enc.encryptedPath,
+        })
       }
       // send multiple files
       else if (sanitized.length > 1 && !hasOpenDialogs) {
@@ -168,20 +180,41 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
             }
 
             for (const file of sanitized) {
-              const msgViewType: Viewtype = isImage(file.parsed)
-                ? 'Image'
-                : 'File'
-              sendMessage(accountId, chat.id, {
-                file: file.pathStr,
-                filename: file.parsed.name + file.parsed.ext,
-                viewtype: msgViewType,
+              const enc = await encryptFileForChat(
+                accountId,
+                chat.id,
+                file.pathStr
+              )
+              if (!enc) {
+                continue
+              }
+              setSharedData({
+                allowDownload: false,
+                allowForward: false,
+                allowedTime: '',
+                FileDirectory: enc.originalPath,
+                oneTimeKey: enc.oneTimeKey,
+                encryptedFilePath: enc.encryptedPath,
+              })
+              await sendMessage(accountId, chat.id, {
+                file: enc.encryptedPath,
+                filename: basename(enc.encryptedPath),
+                viewtype: 'File',
               })
             }
           },
         })
       }
     },
-    [accountId, addFileToDraft, chat, hasOpenDialogs, openDialog, sendMessage]
+    [
+      accountId,
+      addFileToDraft,
+      chat,
+      hasOpenDialogs,
+      openDialog,
+      sendMessage,
+      setSharedData,
+    ]
   )
 
   useEffect(() => {

--- a/packages/frontend/src/components/screens/WelcomeScreen/ScanInvitationCodeScreen.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/ScanInvitationCodeScreen.tsx
@@ -1,0 +1,108 @@
+import React, { useCallback, useRef, useState } from 'react'
+
+import {
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  FooterActionButton,
+  FooterActions,
+} from '../../Dialog'
+import { QrReader, QrCodeScanRef } from '../../QrReader'
+import useProcessQr from '../../../hooks/useProcessQr'
+import useTranslationFunction from '../../../hooks/useTranslationFunction'
+import useAlertDialog from '../../../hooks/dialog/useAlertDialog'
+
+type Props = {
+  selectedAccountId: number
+  onBack: () => void
+  onScanDone: (qrValue: string) => void
+}
+
+export default function ScanInvitationCodeScreen({
+  selectedAccountId,
+  onBack,
+  onScanDone,
+}: Props) {
+  const tx = useTranslationFunction()
+  const processQr = useProcessQr()
+  const openAlertDialog = useAlertDialog()
+  const processingQrCode = useRef(false)
+  const qrReaderRef = useRef<QrCodeScanRef | null>(null)
+  const [readerKey, setReaderKey] = useState(0)
+
+  const handleError = useCallback(
+    (error: any) => {
+      const errorMessage = error?.message || error.toString()
+      openAlertDialog({
+        message: `${tx('qrscan_failed')} ${errorMessage}`,
+      })
+    },
+    [openAlertDialog, tx]
+  )
+
+  const handleScanSuccess = useCallback(
+    async (data: string) => {
+      if (!data || processingQrCode.current) {
+        return
+      }
+      processingQrCode.current = true
+      try {
+        await processQr(selectedAccountId, data, () => onScanDone(data))
+      } catch (error: any) {
+        handleError(error)
+      } finally {
+        processingQrCode.current = false
+      }
+    },
+    [processQr, selectedAccountId, onScanDone, handleError]
+  )
+
+  const handlePasteFromClipboard = useCallback(() => {
+    qrReaderRef.current?.handlePasteFromClipboard()
+  }, [])
+
+  const handleRetryCamera = useCallback(() => {
+    // Re-mount the reader to trigger camera permission flow again.
+    setReaderKey(prev => prev + 1)
+  }, [])
+
+  return (
+    <>
+      <DialogHeader
+        title='Scan Invitation Code'
+        onClickBack={onBack}
+        dataTestid='scan-invitation-code-header'
+      />
+      <DialogBody>
+        <DialogContent>
+          <QrReader
+            key={readerKey}
+            ref={qrReaderRef}
+            onScanSuccess={handleScanSuccess}
+            onError={handleError}
+          />
+          <div style={{ textAlign: 'center', marginTop: 8, opacity: 0.9 }}>
+            Point your camera at the invitation QR code.
+          </div>
+        </DialogContent>
+      </DialogBody>
+      <DialogFooter>
+        <FooterActions align='spaceBetween'>
+          <FooterActionButton
+            onClick={handlePasteFromClipboard}
+            data-testid='scan-invitation-paste'
+          >
+            {tx('global_menu_edit_paste_desktop')}
+          </FooterActionButton>
+          <FooterActionButton
+            onClick={handleRetryCamera}
+            data-testid='scan-invitation-retry'
+          >
+            {tx('retry')}
+          </FooterActionButton>
+        </FooterActions>
+      </DialogFooter>
+    </>
+  )
+}

--- a/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
@@ -4,6 +4,7 @@ import Dialog from '../../Dialog'
 import ImageBackdrop from '../../ImageBackdrop'
 import InstantOnboardingScreen from './InstantOnboardingScreen'
 import OnboardingScreen from './OnboardingScreen'
+import ScanInvitationCodeScreen from './ScanInvitationCodeScreen'
 import useInstantOnboarding from '../../../hooks/useInstantOnboarding'
 import { getConfiguredAccounts } from '../../../backend/account'
 import { BackendRemote, EffectfulBackendActions } from '../../../backend-com'
@@ -23,12 +24,10 @@ type Props = {
  */
 
 export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
-  const {
-    resetInstantOnboarding,
-    showInstantOnboarding,
-    startInstantOnboardingFlow,
-  } = useInstantOnboarding()
+  const { resetInstantOnboarding, showInstantOnboarding } =
+    useInstantOnboarding()
   const [hasConfiguredAccounts, setHasConfiguredAccounts] = useState(false)
+  const [showScanInvitationCode, setShowScanInvitationCode] = useState(false)
   const { openDialog } = useDialog()
 
   useLayoutEffect(() => {
@@ -75,13 +74,21 @@ export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
         dataTestid='onboarding-dialog'
       >
         {!showInstantOnboarding ? (
-          <OnboardingScreen
-            onNextStep={() => startInstantOnboardingFlow()}
-            selectedAccountId={selectedAccountId}
-            hasConfiguredAccounts={hasConfiguredAccounts}
-            onClose={onClose}
-            {...props}
-          />
+          showScanInvitationCode ? (
+            <ScanInvitationCodeScreen
+              selectedAccountId={selectedAccountId}
+              onBack={() => setShowScanInvitationCode(false)}
+              onScanDone={() => setShowScanInvitationCode(false)}
+            />
+          ) : (
+            <OnboardingScreen
+              onNextStep={() => setShowScanInvitationCode(true)}
+              selectedAccountId={selectedAccountId}
+              hasConfiguredAccounts={hasConfiguredAccounts}
+              onClose={onClose}
+              {...props}
+            />
+          )
         ) : (
           <InstantOnboardingScreen
             selectedAccountId={selectedAccountId}

--- a/packages/frontend/src/utils/privittyEncryptFile.ts
+++ b/packages/frontend/src/utils/privittyEncryptFile.ts
@@ -6,7 +6,6 @@ import { getLogger } from '../../../shared/logger'
 
 const log = getLogger('renderer/privittyEncryptFile')
 
-/** Same defaults as group / menu path in menuAttachment.tsx (addFilenameFile). */
 const DEFAULT_FILE_ATTR = {
   allowDownload: false,
   allowForward: false,
@@ -20,9 +19,7 @@ export type EncryptFileForChatResult = {
 }
 
 /**
- * Encrypts a local file for the given chat using the same APIs as menuAttachment:
- * - group: `groupFileEncryptRequest`
- * - 1:1: `fileEncryptRequest` with default attributes
+ * Encrypts a local file for the given chat using fileEncryptRequest as menuAttachment:
  */
 export async function encryptFileForChat(
   accountId: number,
@@ -32,7 +29,10 @@ export async function encryptFileForChat(
   const normalized = plainFilePath.replace(/\\/g, '/')
   let encryptedFile: string
   try {
-    const basicChat = await BackendRemote.rpc.getBasicChatInfo(accountId, chatId)
+    const basicChat = await BackendRemote.rpc.getBasicChatInfo(
+      accountId,
+      chatId
+    )
     if (basicChat.chatType === C.DC_CHAT_TYPE_GROUP) {
       encryptedFile = await runtime.PrivittySendMessage('sendEvent', {
         event_type: 'groupFileEncryptRequest',

--- a/packages/frontend/src/utils/privittyEncryptFile.ts
+++ b/packages/frontend/src/utils/privittyEncryptFile.ts
@@ -1,0 +1,98 @@
+import { runtime } from '@deltachat-desktop/runtime-interface'
+import { C } from '@privitty/jsonrpc-client'
+
+import { BackendRemote } from '../backend-com'
+import { getLogger } from '../../../shared/logger'
+
+const log = getLogger('renderer/privittyEncryptFile')
+
+/** Same defaults as group / menu path in menuAttachment.tsx (addFilenameFile). */
+const DEFAULT_FILE_ATTR = {
+  allowDownload: false,
+  allowForward: false,
+  allowedTime: '',
+} as const
+
+export type EncryptFileForChatResult = {
+  encryptedPath: string
+  oneTimeKey: string
+  originalPath: string
+}
+
+/**
+ * Encrypts a local file for the given chat using the same APIs as menuAttachment:
+ * - group: `groupFileEncryptRequest`
+ * - 1:1: `fileEncryptRequest` with default attributes
+ */
+export async function encryptFileForChat(
+  accountId: number,
+  chatId: number,
+  plainFilePath: string
+): Promise<EncryptFileForChatResult | null> {
+  const normalized = plainFilePath.replace(/\\/g, '/')
+  let encryptedFile: string
+  try {
+    const basicChat = await BackendRemote.rpc.getBasicChatInfo(accountId, chatId)
+    if (basicChat.chatType === C.DC_CHAT_TYPE_GROUP) {
+      encryptedFile = await runtime.PrivittySendMessage('sendEvent', {
+        event_type: 'groupFileEncryptRequest',
+        event_data: {
+          group_chat_id: String(chatId),
+          file_path: normalized,
+        },
+      })
+    } else {
+      encryptedFile = await runtime.PrivittySendMessage('sendEvent', {
+        event_type: 'fileEncryptRequest',
+        event_data: {
+          chat_id: String(chatId),
+          file_path: normalized,
+          allow_download: DEFAULT_FILE_ATTR.allowDownload,
+          allow_forward: DEFAULT_FILE_ATTR.allowForward,
+          access_duration: Number(DEFAULT_FILE_ATTR.allowedTime),
+        },
+      })
+    }
+  } catch (e) {
+    log.error('encryptFileForChat: PrivittySendMessage failed', e)
+    return null
+  }
+
+  const data = JSON.parse(encryptedFile)
+  const prvFileName = data.result?.data?.prv_file_name
+  const oneTimeKey = data.result?.data?.one_time_key
+
+  if (!prvFileName || prvFileName === '') {
+    log.error('encryptFileForChat: empty prv_file_name')
+    runtime.showNotification({
+      title: 'Privitty',
+      body: 'Encrypted file name is empty or undefined',
+      icon: null,
+      chatId: 0,
+      messageId: 0,
+      accountId,
+      notificationType: 0,
+    })
+    return null
+  }
+
+  if (!(await runtime.checkFileExists(prvFileName))) {
+    log.error('encryptFileForChat: encrypted file does not exist', prvFileName)
+    runtime.showNotification({
+      title: 'Privitty',
+      body: 'Encrypted file does not exist',
+      icon: null,
+      chatId: 0,
+      messageId: 0,
+      accountId,
+      notificationType: 0,
+    })
+    return null
+  }
+
+  return {
+    encryptedPath: prvFileName,
+    oneTimeKey: oneTimeKey ?? '',
+    originalPath: normalized,
+  }
+}

--- a/packages/frontend/themes/_themebase.scss
+++ b/packages/frontend/themes/_themebase.scss
@@ -88,6 +88,7 @@ $scrollbarTransparency: 0.34 !default;
   /* ChatView */
   --chatViewBg: #{$bgChatView};
   --chatViewBgImgPath: #{$bgImage};
+  --messageOutgoingTextColor: #fff;
   /* ChatView - Composer */
   --composerBg: #{$bgPrimary};
   --composerText: #{$textPrimary};


### PR DESCRIPTION
- Added QR scanner to the onboarding screen on Create New Account
- Implemented drag-and-drop support for file encryption
- Updated outgoing message text color to white for better readability

Bug: #87 
Test: Tested and verified on Desktop (mac air m2)