### PR TITLE
Fix file attributes handling for drag-and-drop uploads

### DIFF
--- a/packages/frontend/scss/misc/_context_menu.scss
+++ b/packages/frontend/scss/misc/_context_menu.scss
@@ -59,6 +59,7 @@
     width: 100%;
     line-height: 20px;
     padding: 12px;
+    padding-inline: 22px;
     gap: 20px;
     white-space: nowrap;
     display: flex;

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useCallback } from 'react'
 import { basename, join, parse } from 'path'
-import { T } from '@privitty/jsonrpc-client'
+import { C, T } from '@privitty/jsonrpc-client'
 
 import Composer, { useDraft } from '../composer/Composer'
 import { getLogger } from '../../../../shared/logger'
@@ -16,6 +16,10 @@ import useDialog from '../../hooks/dialog/useDialog'
 import useMessage from '../../hooks/chat/useMessage'
 import { useSharedData } from '../../contexts/FileAttribContext'
 import { encryptFileForChat } from '../../utils/privittyEncryptFile'
+import SmallSelectDialogPrivitty, {
+  SelectedValue,
+} from '../SmallSelectDialogPrivitty'
+import { BackendRemote } from '../../backend-com'
 
 const log = getLogger('renderer/MessageListAndComposer')
 
@@ -142,62 +146,125 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
         // (unless the file has no extension, then the things are even worse).
         .map(path => ({ parsed: parse(path), pathStr: path }))
 
-      // send single file — encrypt via Privitty before adding to draft (same as menuAttachment)
+      // send single file — open file attribute dialog first
       if (sanitized.length == 1) {
         const file = sanitized[0]
-        const enc = await encryptFileForChat(accountId, chat.id, file.pathStr)
-        if (!enc) {
-          return
-        }
-        await addFileToDraft(
-          enc.encryptedPath,
-          basename(enc.encryptedPath),
-          'File'
-        )
-        setSharedData({
-          allowDownload: false,
-          allowForward: false,
-          allowedTime: '',
-          FileDirectory: enc.originalPath,
-          oneTimeKey: enc.oneTimeKey,
-          encryptedFilePath: enc.encryptedPath,
+        if (hasOpenDialogs) return
+        openDialog(SmallSelectDialogPrivitty, {
+          title: 'File Attributes',
+          initialSelectedValue: {
+            allowDownload: false,
+            allowForward: false,
+            allowedTime: '',
+          },
+          onSave: async (selectedValue: SelectedValue) => {
+            // For group chats, we keep the same defaults as menuAttachment.
+            let fileAttribute: SelectedValue = selectedValue
+            try {
+              const basicChat = await BackendRemote.rpc.getBasicChatInfo(
+                accountId,
+                chat.id
+              )
+              if (basicChat.chatType === C.DC_CHAT_TYPE_GROUP) {
+                fileAttribute = {
+                  allowDownload: false,
+                  allowForward: false,
+                  allowedTime: '',
+                }
+              }
+            } catch {
+              // Ignore chat type check errors and use user selection.
+            }
+
+            const enc = await encryptFileForChat(
+              accountId,
+              chat.id,
+              file.pathStr,
+              fileAttribute
+            )
+            if (!enc) return
+
+            await addFileToDraft(
+              enc.encryptedPath,
+              basename(enc.encryptedPath),
+              'File'
+            )
+            setSharedData({
+              allowDownload: fileAttribute.allowDownload,
+              allowForward: fileAttribute.allowForward,
+              allowedTime: fileAttribute.allowedTime,
+              FileDirectory: enc.originalPath,
+              oneTimeKey: enc.oneTimeKey,
+              encryptedFilePath: enc.encryptedPath,
+            })
+          },
         })
       }
       // send multiple files
       else if (sanitized.length > 1 && !hasOpenDialogs) {
-        openDialog(ConfirmSendingFiles, {
-          sanitizedFileList: sanitized.map(path => ({
-            name: path.parsed.name,
-          })),
-          chatName: chat.name,
-          onClick: async (isConfirmed: boolean) => {
-            if (!isConfirmed) {
-              return
+        openDialog(SmallSelectDialogPrivitty, {
+          title: 'File Attributes',
+          initialSelectedValue: {
+            allowDownload: false,
+            allowForward: false,
+            allowedTime: '',
+          },
+          onSave: async (selectedValue: SelectedValue) => {
+            let fileAttribute: SelectedValue = selectedValue
+            try {
+              const basicChat = await BackendRemote.rpc.getBasicChatInfo(
+                accountId,
+                chat.id
+              )
+              if (basicChat.chatType === C.DC_CHAT_TYPE_GROUP) {
+                fileAttribute = {
+                  allowDownload: false,
+                  allowForward: false,
+                  allowedTime: '',
+                }
+              }
+            } catch {
+              // Ignore chat type check errors and use user selection.
             }
 
-            for (const file of sanitized) {
-              const enc = await encryptFileForChat(
-                accountId,
-                chat.id,
-                file.pathStr
-              )
-              if (!enc) {
-                continue
-              }
-              setSharedData({
-                allowDownload: false,
-                allowForward: false,
-                allowedTime: '',
-                FileDirectory: enc.originalPath,
-                oneTimeKey: enc.oneTimeKey,
-                encryptedFilePath: enc.encryptedPath,
+            // SmallSelectDialogPrivitty closes *after* onSave returns,
+            // so we delay to avoid two dialogs being open at once.
+            setTimeout(() => {
+              openDialog(ConfirmSendingFiles, {
+                sanitizedFileList: sanitized.map(path => ({
+                  name: path.parsed.name,
+                })),
+                chatName: chat.name,
+                onClick: async (isConfirmed: boolean) => {
+                  if (!isConfirmed) return
+
+                  for (const file of sanitized) {
+                    const enc = await encryptFileForChat(
+                      accountId,
+                      chat.id,
+                      file.pathStr,
+                      fileAttribute
+                    )
+                    if (!enc) continue
+
+                    setSharedData({
+                      allowDownload: fileAttribute.allowDownload,
+                      allowForward: fileAttribute.allowForward,
+                      allowedTime: fileAttribute.allowedTime,
+                      FileDirectory: enc.originalPath,
+                      oneTimeKey: enc.oneTimeKey,
+                      encryptedFilePath: enc.encryptedPath,
+                    })
+
+                    await sendMessage(accountId, chat.id, {
+                      file: enc.encryptedPath,
+                      filename: basename(enc.encryptedPath),
+                      viewtype: 'File',
+                    })
+                  }
+                },
               })
-              await sendMessage(accountId, chat.id, {
-                file: enc.encryptedPath,
-                filename: basename(enc.encryptedPath),
-                viewtype: 'File',
-              })
-            }
+            }, 0)
           },
         })
       }

--- a/packages/frontend/src/utils/privittyEncryptFile.ts
+++ b/packages/frontend/src/utils/privittyEncryptFile.ts
@@ -24,7 +24,12 @@ export type EncryptFileForChatResult = {
 export async function encryptFileForChat(
   accountId: number,
   chatId: number,
-  plainFilePath: string
+  plainFilePath: string,
+  fileAttribute: {
+    allowDownload: boolean
+    allowForward: boolean
+    allowedTime: string
+  } = DEFAULT_FILE_ATTR
 ): Promise<EncryptFileForChatResult | null> {
   const normalized = plainFilePath.replace(/\\/g, '/')
   let encryptedFile: string
@@ -47,9 +52,9 @@ export async function encryptFileForChat(
         event_data: {
           chat_id: String(chatId),
           file_path: normalized,
-          allow_download: DEFAULT_FILE_ATTR.allowDownload,
-          allow_forward: DEFAULT_FILE_ATTR.allowForward,
-          access_duration: Number(DEFAULT_FILE_ATTR.allowedTime),
+          allow_download: fileAttribute.allowDownload,
+          allow_forward: fileAttribute.allowForward,
+          access_duration: Number(fileAttribute.allowedTime || 0),
         },
       })
     }


### PR DESCRIPTION
Fixed an issue where file attributes were not properly set when uploading files using drag-and-drop.

Now the following permissions are correctly included when sending files:
- Allow Download
- Allow Forward
- Access Duration